### PR TITLE
Fix Codecov upload authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       - master
     tags: '*'
   workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -46,6 +49,8 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
+          fail_ci_if_error: true
+          use_oidc: true
 #  docs:
 #    name: Documentation
 #    runs-on: ubuntu-latest


### PR DESCRIPTION
Use GitHub OIDC for Codecov uploads and make upload failures visible in CI.